### PR TITLE
Update server-side-rendering.md

### DIFF
--- a/docs/guides/server-side-rendering.md
+++ b/docs/guides/server-side-rendering.md
@@ -39,8 +39,8 @@ This will create the Hydrate Module which you can export separately via:
     ...
     "./hydrate": {
       "types": "./hydrate/index.d.ts",
-      "import": "./hydrate/index.js",
-      "require": "./hydrate/index.cjs.js",
+      "import": "./hydrate/index.mjs",
+      "require": "./hydrate/index.js",
       "default": "./hydrate/index.js"
     },
     ...

--- a/versioned_docs/version-v4.31/guides/server-side-rendering.md
+++ b/versioned_docs/version-v4.31/guides/server-side-rendering.md
@@ -39,8 +39,8 @@ This will create the Hydrate Module which you can export separately via:
     ...
     "./hydrate": {
       "types": "./hydrate/index.d.ts",
-      "import": "./hydrate/index.js",
-      "require": "./hydrate/index.cjs.js",
+      "import": "./hydrate/index.mjs",
+      "require": "./hydrate/index.js",
       "default": "./hydrate/index.js"
     },
     ...


### PR DESCRIPTION
The export configuration for the hydrate module are inaccurate. There is no `index.cjs.js` file being produced by the `dist-hydrate-script` output target.