### PR TITLE
docs(stencil-docs): adding clarifying info boxes for the  command

### DIFF
--- a/docs/config/cli.md
+++ b/docs/config/cli.md
@@ -40,6 +40,10 @@ Builds a Stencil project. The flags below are the available options for the `bui
 Performs a one-time generation of documentation for your project.
 For more information on documentation generation, please see the [Documentation Generation section](../documentation-generation/01-overview.md).
 
+:::info
+This command runs with dev mode enabled, which does not run a full build. As a result, documentation that needs to be built first, like CSS styles, will not be generated. You will need to run `npx stencil build --docs` to generate documentation that requires building.
+:::
+
 ## `stencil generate`
 
 Alias: `stencil g`

--- a/docs/documentation-generation/docs-readme.md
+++ b/docs/documentation-generation/docs-readme.md
@@ -59,6 +59,10 @@ npx stencil docs
 ```
 Running `stencil docs` will generate documentation for [all documentation output targets](./01-overview.md), not just `docs-readme`.
 
+:::info
+The `npx stencil docs` command runs with dev mode enabled, which does not run a full build. As a result, documentation that needs to be built first, like CSS styles, will not be generated. You will need to run `npx stencil build --docs` to generate documentation that requires building.
+:::
+
 ## README Sections
 
 Most generated markdown content will automatically be generated without requiring any additional configuration.

--- a/versioned_docs/version-v4.30/config/cli.md
+++ b/versioned_docs/version-v4.30/config/cli.md
@@ -40,6 +40,10 @@ Builds a Stencil project. The flags below are the available options for the `bui
 Performs a one-time generation of documentation for your project.
 For more information on documentation generation, please see the [Documentation Generation section](../documentation-generation/01-overview.md).
 
+:::info
+This command runs with dev mode enabled, which does not run a full build. As a result, documentation that needs to be built first, like CSS styles, will not be generated. You will need to run `npx stencil build --docs` to generate documentation that requires building.
+:::
+
 ## `stencil generate`
 
 Alias: `stencil g`

--- a/versioned_docs/version-v4.30/documentation-generation/docs-readme.md
+++ b/versioned_docs/version-v4.30/documentation-generation/docs-readme.md
@@ -59,6 +59,10 @@ npx stencil docs
 ```
 Running `stencil docs` will generate documentation for [all documentation output targets](./01-overview.md), not just `docs-readme`.
 
+:::info
+The `npx stencil docs` command runs with dev mode enabled, which does not run a full build. As a result, documentation that needs to be built first, like CSS styles, will not be generated. You will need to run `npx stencil build --docs` to generate documentation that requires building.
+:::
+
 ## README Sections
 
 Most generated markdown content will automatically be generated without requiring any additional configuration.

--- a/versioned_docs/version-v4.31/config/cli.md
+++ b/versioned_docs/version-v4.31/config/cli.md
@@ -40,6 +40,10 @@ Builds a Stencil project. The flags below are the available options for the `bui
 Performs a one-time generation of documentation for your project.
 For more information on documentation generation, please see the [Documentation Generation section](../documentation-generation/01-overview.md).
 
+:::info
+This command runs with dev mode enabled, which does not run a full build. As a result, documentation that needs to be built first, like CSS styles, will not be generated. You will need to run `npx stencil build --docs` to generate documentation that requires building.
+:::
+
 ## `stencil generate`
 
 Alias: `stencil g`

--- a/versioned_docs/version-v4.31/documentation-generation/docs-readme.md
+++ b/versioned_docs/version-v4.31/documentation-generation/docs-readme.md
@@ -59,6 +59,10 @@ npx stencil docs
 ```
 Running `stencil docs` will generate documentation for [all documentation output targets](./01-overview.md), not just `docs-readme`.
 
+:::info
+The `npx stencil docs` command runs with dev mode enabled, which does not run a full build. As a result, documentation that needs to be built first, like CSS styles, will not be generated. You will need to run `npx stencil build --docs` to generate documentation that requires building.
+:::
+
 ## README Sections
 
 Most generated markdown content will automatically be generated without requiring any additional configuration.


### PR DESCRIPTION
While investigating solutions to [core/#5883](https://github.com/stenciljs/core/issues/5883), I found that the current behavior of the `stencil docs` command seems intentional and that generating CSS docs would require a build, which the `stencil docs` command does not due.

After talking to Christian about this, we decided that, for now, the approach to resolve this issue would be updating the docs to clarify this behavior so prevent confusion in the future.

In the future, we will rework the Stencil CLI so that things like this are less confusing and more intuitive.