### PR TITLE
docs(ssr): add more clarity on the two approaches in Next.js

### DIFF
--- a/docs/testing/04-jest.md
+++ b/docs/testing/04-jest.md
@@ -18,7 +18,7 @@ Stencil provides a Jest runner specifically designed for testing Stencil compone
 - 🔧 **TypeScript Support** - Full TypeScript support with proper type definitions
 - 🎨 **Custom Matchers** - Additional Jest matchers for HTML and component testing
 - 📱 **Component Testing** - Test Stencil components in isolation with `newSpecPage()`
-- 📸 **Shadow DOM Testing** - Full support for testing and snapshotting Shadow DOM content
+- 📸 **Shadow DOM Testing** - Full support for testing and capturing Shadow DOM snapshots
 
 ## Installation
 

--- a/versioned_docs/version-v4.33/testing/04-jest.md
+++ b/versioned_docs/version-v4.33/testing/04-jest.md
@@ -18,7 +18,7 @@ Stencil provides a Jest runner specifically designed for testing Stencil compone
 - 🔧 **TypeScript Support** - Full TypeScript support with proper type definitions
 - 🎨 **Custom Matchers** - Additional Jest matchers for HTML and component testing
 - 📱 **Component Testing** - Test Stencil components in isolation with `newSpecPage()`
-- 📸 **Shadow DOM Testing** - Full support for testing and snapshotting Shadow DOM content
+- 📸 **Shadow DOM Testing** - Full support for testing and capturing Shadow DOM snapshots
 
 ## Installation
 

--- a/versioned_docs/version-v4.34/testing/04-jest.md
+++ b/versioned_docs/version-v4.34/testing/04-jest.md
@@ -18,7 +18,7 @@ Stencil provides a Jest runner specifically designed for testing Stencil compone
 - 🔧 **TypeScript Support** - Full TypeScript support with proper type definitions
 - 🎨 **Custom Matchers** - Additional Jest matchers for HTML and component testing
 - 📱 **Component Testing** - Test Stencil components in isolation with `newSpecPage()`
-- 📸 **Shadow DOM Testing** - Full support for testing and snapshotting Shadow DOM content
+- 📸 **Shadow DOM Testing** - Full support for testing and capturing Shadow DOM snapshots
 
 ## Installation
 

--- a/versioned_docs/version-v4.35/testing/04-jest.md
+++ b/versioned_docs/version-v4.35/testing/04-jest.md
@@ -18,7 +18,7 @@ Stencil provides a Jest runner specifically designed for testing Stencil compone
 - 🔧 **TypeScript Support** - Full TypeScript support with proper type definitions
 - 🎨 **Custom Matchers** - Additional Jest matchers for HTML and component testing
 - 📱 **Component Testing** - Test Stencil components in isolation with `newSpecPage()`
-- 📸 **Shadow DOM Testing** - Full support for testing and snapshotting Shadow DOM content
+- 📸 **Shadow DOM Testing** - Full support for testing and capturing Shadow DOM snapshots
 
 ## Installation
 


### PR DESCRIPTION
With https://github.com/stenciljs/output-targets/pull/683 providing improvements to the runtime approach we should update our docs around this.